### PR TITLE
Fixed incorrect responses to "TURN" throughout Zork I, II and III (could use some work)

### DIFF
--- a/verbs.zil
+++ b/verbs.zil
@@ -1486,24 +1486,16 @@ CR>)
 		<TELL "Nothing happens." CR>)>>
 
 <ROUTINE PRE-TURN ()
-	 %<COND (<==? ,ZORK-NUMBER 3>
-		 '<COND (<AND <EQUAL? ,PRSI <> ,ROOMS>
-			      <EQUAL? ,PRSO ,DIAL ,TM-DIAL ,T-BAR>>
-			 <TELL
-"You should turn the " D ,PRSO " to something." CR>
-			 <RTRUE>)>)
-		(ELSE T)>
-	 <COND (%<COND (<==? ,ZORK-NUMBER 1>
-			'<AND <EQUAL? ,PRSI <> ,ROOMS>
-			      <NOT <EQUAL? ,PRSO ,BOOK>>>)
-		       (ELSE
-			'<EQUAL? ,PRSI <> ,ROOMS>)>
-		<TELL "Your bare hands don't appear to be enough." CR>)
-	       (<NOT <FSET? ,PRSO ,TURNBIT>>
+	 <COND (<NOT <FSET? ,PRSO ,TURNBIT>>
 		<TELL "You can't turn that!" CR>)>>
 
 <ROUTINE V-TURN ()
-	 <TELL "This has no effect." CR>>
+	 <COND (<EQUAL? ,PRSI <> ,ROOMS ,HANDS>
+		<TELL "Your bare hands don't appear to be enough." CR>)
+	       (<NOT <FSET? ,PRSI ,TOOLBIT>>
+		<TELL "You certainly can't turn it with a " D ,PRSI "." CR>)
+	       (T
+		<TELL "This has no effect." CR>)>>
 
 <ROUTINE V-UNLOCK ()
 	 <V-LOCK>>


### PR DESCRIPTION
Here's my attempt at fixing some incorrect responses to the "TURN" action. See https://github.com/the-infocom-files/zork-substrate/issues/4

It also depends on changes to Zork I, II and III, but I'm making separate pull requests for them since they're in other repositories.

After the changes, this is what I get:

Objects without ```TURNBIT``` will print "You can't turn that!" in response to any "TURN" action.

**Zork I - the bolt**

```
>TURN BOLT
Your bare hands don't appear to be enough.

>TURN BOLT WITH HANDS
Your bare hands don't appear to be enough.

>TURN BOLT WITH SCREWDRIVER
The bolt won't turn using the screwdriver.

>TURN BOLT WITH WRENCH
The bolt won't turn using your best effort.
```

**Zork I - the switch**

```
>TURN SWITCH
Your bare hands don't appear to be enough.

>TURN SWITCH WITH HANDS
Your bare hands don't appear to be enough.

>TURN SWITCH WITH WRENCH
It seems that a wrench won't do.

>TURN SWITCH WITH SCREWDRIVER
The machine comes to life (figuratively) with a dazzling display of colored
lights and bizarre noises. After a few moments, the excitement abates.
```

**Zork I - the book**

Any "TURN" command shows the other page of the book.

**Zork II - ordering the robot**

```
>ROBOT, TURN ROBOT
"My programming is insufficient to allow me to perform that task."

>ROBOT, TURN KEY
"Whirr, buzz, click!"
"My programming is insufficient to allow me to perform that task."

>ROBOT, TURN SWORD
"Whirr, buzz, click!"
You can't turn that!
```

Not ideal, and I still don't know why the robot responds to "TURN".

**Zork II - the key**

Any "TURN" action when the key isn't in either keyhole is the same as rubbing it, i.e. prints a HACK-HACK message.

Any "TURN" action when the key is in either keyhole either locks or unlocks the door.

**Zork II - the menhir**

Any "TURN" action prints the "The menhir weighs many tons..." message.

**Zork III - asking the Dungeon Master to turn the dial**

```
>MASTER, TURN DIAL
"If you wish," he replies.
You must specify what to set the dial to.

>MASTER, TURN DIAL WITH HANDS
"If you wish," he replies.
You must specify what to set the dial to.

>MASTER, TURN DIAL WITH SWORD
"If you wish," he replies.
The dial face only contains numbers.

>MASTER, TURN DIAL TO 4
"If you wish," he replies.
```

**Zork III - the dial in the endgame**

```
>TURN DIAL
You must specify what to set the dial to.

>TURN DIAL WITH HANDS
You must specify what to set the dial to.

>TURN DIAL WITH SWORD
The dial face only contains numbers.

>TURN DIAL TO 4
The dial now points to 4.
```

**Zork III - the T-bar**

Any "TURN" action prints the "You don't have enough leverage..." message.

**Zork III - the compass rose**

Any "TURN" action prints the "The compass rose is made of stone..." message.

**Zork III - the time machine dial**

```
>TURN DIAL
You have to say what to turn it to!

>TURN DIAL WITH HANDS
You have to say what to turn it to!

>TURN DIAL WITH SWORD
You can't do that!

>TURN DIAL TO 444
The dial is set to 444.
```